### PR TITLE
Allow (optional) weak type checking when comparing incompatible types, improved null handling

### DIFF
--- a/Evaluant.Calculator.Tests/Fixtures.cs
+++ b/Evaluant.Calculator.Tests/Fixtures.cs
@@ -664,6 +664,24 @@ namespace NCalc.Tests
 
             Assert.AreEqual(11M, e.Evaluate());
         }
-    }
+
+		[TestMethod]
+		public void ShouldCompareNullableToNonNullable() {
+			var e = new Expression("[x] = 5");
+
+			e.Parameters["x"] = (int?)5;
+			Assert.IsTrue((bool)e.Evaluate());
+
+			e.Parameters["x"] = (int?)6;
+			Assert.IsFalse((bool)e.Evaluate());
+		}
+
+		[TestMethod]
+		public void ShouldCompareNullToString() {
+			var e = new Expression("[x] = 'foo'");
+			e.Parameters["x"] = null;
+			Assert.IsFalse((bool)e.Evaluate());
+		}
+	}
 }
 

--- a/Evaluant.Calculator.Tests/Fixtures.cs
+++ b/Evaluant.Calculator.Tests/Fixtures.cs
@@ -677,6 +677,13 @@ namespace NCalc.Tests
 		}
 
 		[TestMethod]
+		public void ShouldCompareNullToNull() {
+			var e = new Expression("[x] = null");
+			e.Parameters["x"] = null;
+			Assert.IsTrue((bool)e.Evaluate());
+		}
+
+		[TestMethod]
 		public void ShouldCompareNullToString() {
 			var e = new Expression("[x] = 'foo'");
 			e.Parameters["x"] = null;

--- a/Evaluant.Calculator.Tests/Fixtures.cs
+++ b/Evaluant.Calculator.Tests/Fixtures.cs
@@ -689,6 +689,20 @@ namespace NCalc.Tests
 			e.Parameters["x"] = null;
 			Assert.IsFalse((bool)e.Evaluate());
 		}
+
+		[TestMethod]
+		public void ShouldCompareNullToInt() {
+			var e = new Expression("[x] = 5");
+			e.Parameters["x"] = null;
+			Assert.IsFalse((bool)e.Evaluate());
+		}
+
+		[TestMethod]
+		public void ShouldCompareNullToDate() {
+			var e = new Expression("[x] = #1/1/2016#");
+			e.Parameters["x"] = null;
+			Assert.IsFalse((bool)e.Evaluate());
+		}
 	}
 }
 

--- a/Evaluant.Calculator/Domain/BinaryExpression.cs
+++ b/Evaluant.Calculator/Domain/BinaryExpression.cs
@@ -19,6 +19,24 @@ namespace NCalc.Domain
         {
             visitor.Visit(this);
         }
+
+		public bool IsBoolean {
+			get {
+				switch (Type) {
+					case BinaryExpressionType.And:
+					case BinaryExpressionType.Or:
+					case BinaryExpressionType.NotEqual:
+					case BinaryExpressionType.LesserOrEqual:
+					case BinaryExpressionType.GreaterOrEqual:
+					case BinaryExpressionType.Lesser:
+					case BinaryExpressionType.Greater:
+					case BinaryExpressionType.Equal:
+						return true;
+					default:
+						return false;
+				}
+			}
+		}
     }
 
 	public enum BinaryExpressionType

--- a/Evaluant.Calculator/Domain/EvaluationVisitor.cs
+++ b/Evaluant.Calculator/Domain/EvaluationVisitor.cs
@@ -37,8 +37,8 @@ namespace NCalc.Domain
 
         private static Type GetMostPreciseType(object a, object b) 
 		{
-	        var t1 = (a == null) ? null : a.GetType();
-	        var t2 = (b == null) ? null : b.GetType();
+	        var t1 = (a == null) ? typeof(object) : a.GetType();
+	        var t2 = (b == null) ? typeof(object) : b.GetType();
 	        return CommonTypes.FirstOrDefault(t => t1 == t || t2 == t) ?? t1;
         }
 
@@ -647,10 +647,12 @@ namespace NCalc.Domain
                 // Calls external implementation
                 OnEvaluateParameter(parameter.Name, args);
 
-                if (!args.HasResult)
+				if (args.HasResult)
+					Result = args.Result;
+				else if (parameter.Name.Equals("null", StringComparison.InvariantCulture))
+					Result = null;
+				else
                     throw new ArgumentException("Parameter was not defined", parameter.Name);
-
-                Result = args.Result;
             }
         }
 

--- a/Evaluant.Calculator/Domain/EvaluationVisitor.cs
+++ b/Evaluant.Calculator/Domain/EvaluationVisitor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NCalc.Domain
 {
@@ -32,30 +33,18 @@ namespace NCalc.Domain
             throw new Exception("The method or operation is not implemented.");
         }
 
-        private static Type[] CommonTypes = new[] { typeof(Int64), typeof(Double), typeof(Boolean), typeof(String), typeof(Decimal) };
+        private static Type[] CommonTypes = { typeof(Int64), typeof(Double), typeof(Boolean), typeof(String), typeof(Decimal) };
 
-    /// <summary>
-        /// Gets the the most precise type.
-        /// </summary>
-        /// <param name="a">Type a.</param>
-        /// <param name="b">Type b.</param>
-        /// <returns></returns>
-        private static Type GetMostPreciseType(Type a, Type b)
-        {
-            foreach (Type t in CommonTypes)
-            {
-                if (a == t || b == t)
-                {
-                    return t;
-                }
-            }
-
-            return a;
+        private static Type GetMostPreciseType(object a, object b) 
+		{
+	        var t1 = (a == null) ? null : a.GetType();
+	        var t2 = (b == null) ? null : b.GetType();
+	        return CommonTypes.FirstOrDefault(t => t1 == t || t2 == t) ?? t1;
         }
 
         public int CompareUsingMostPreciseType(object a, object b)
         {
-            Type mpt = GetMostPreciseType(a.GetType(), b.GetType());
+            Type mpt = GetMostPreciseType(a, b);
             return Comparer.Default.Compare(Convert.ChangeType(a, mpt), Convert.ChangeType(b, mpt));
         }
 

--- a/Evaluant.Calculator/EvaluationOption.cs
+++ b/Evaluant.Calculator/EvaluationOption.cs
@@ -7,24 +7,29 @@ namespace NCalc
     [Flags]
     public enum EvaluateOptions
     {
-        // Summary:
-        //     Specifies that no options are set.
-        None = 1,
-        //
-        // Summary:
-        //     Specifies case-insensitive matching.
-        IgnoreCase = 2,
-        //
-        // Summary:
-        //     No-cache mode. Ingores any pre-compiled expression in the cache.
-        NoCache = 4,
-        //
-        // Summary:
-        //     Treats parameters as arrays and result a set of results.
-        IterateParameters = 8,
-        //
-        // Summary:
-        //     When using Round(), if a number is halfway between two others, it is rounded toward the nearest number that is away from zero. 
-        RoundAwayFromZero = 16
-    }
+		/// <summary>
+		/// Specifies that no options are set.
+		/// </summary>
+		None = 1,
+		/// <summary>
+		/// Specifies case-insensitive matching.
+		/// </summary>
+		IgnoreCase = 2,
+		/// <summary>
+		/// No-cache mode. Ingores any pre-compiled expression in the cache.
+		/// </summary>
+		NoCache = 4,
+		/// <summary>
+		/// Treats parameters as arrays and result a set of results.
+		/// </summary>
+		IterateParameters = 8,
+		/// <summary>
+		/// When using Round(), if a number is halfway between two others, it is rounded toward the nearest number that is away from zero. 
+		/// </summary>
+		RoundAwayFromZero = 16,
+		/// <summary>
+		/// Causes incompatible type comparisons to evaluate to false instead of throwing an EvaluationException.
+		/// </summary>
+		WeakTypeChecking = 32
+	}
 }


### PR DESCRIPTION
Previously this test failed with a NullReferenceException (on x.GetType() deep inside EvaluationVisitor):

```
[TestMethod]
public void ShouldCompareNullToString() {
    var e = new Expression("[x] = 'foo'");
    e.Parameters["x"] = null;
    Assert.IsFalse((bool)e.Evaluate());
}
```

When comparing null to a NON-nullable value (such as an integer) and an exception is thrown, an argument could be made that that was the author's intent. However, I believe the above issue is a legitimate bug.
