### PR TITLE
Add support to ignore parameter case.

### DIFF
--- a/Evaluant.Calculator.Tests/Fixtures.cs
+++ b/Evaluant.Calculator.Tests/Fixtures.cs
@@ -424,6 +424,35 @@ namespace NCalc.Tests
         }
 
         [Test]
+        public void ShouldHandleParameterCaseSensitiveness()
+        {
+            var e = new Expression("x*2", EvaluateOptions.IgnoreCase);
+            e.Parameters["X"] = 2;
+            Assert.AreEqual(4, e.Evaluate());
+
+            e = new Expression("x*2");
+            e.Parameters["x"] = 2;
+            Assert.AreEqual(4, e.Evaluate());
+
+            try
+            {
+                e = new Expression("x*2");
+                e.Parameters["X"] = 2;
+                Assert.AreEqual(4, e.Evaluate());
+            }
+            catch (ArgumentException)
+            {
+                return;
+            }
+            catch (Exception)
+            {
+                Assert.Fail("Unexpected exception");
+            }
+
+            Assert.Fail("Should throw ArgumentException");
+        }
+
+        [Test]
         public void ShouldHandleCustomParametersWhenNoSpecificParameterIsDefined()
         {
             var e = new Expression("Round(Pow([Pi], 2) + Pow([Pi], 2) + 10, 2)");

--- a/Evaluant.Calculator/Expression.cs
+++ b/Evaluant.Calculator/Expression.cs
@@ -13,6 +13,8 @@ namespace NCalc
     {
         public EvaluateOptions Options { get; set; }
 
+        private bool IgnoreCase => (Options & EvaluateOptions.IgnoreCase) == EvaluateOptions.IgnoreCase;
+
         /// <summary>
         /// Textual representation of the expression to evaluate.
         /// </summary>
@@ -262,7 +264,7 @@ namespace NCalc
 
         public Dictionary<string, object> Parameters
         {
-            get { return parameters ?? (parameters = new Dictionary<string, object>()); }
+            get { return parameters ?? (parameters = new Dictionary<string, object>(IgnoreCase ? StringComparer.CurrentCultureIgnoreCase : StringComparer.CurrentCulture)); }
             set { parameters = value; }
         }
     }

--- a/Evaluant.Calculator/Expression.cs
+++ b/Evaluant.Calculator/Expression.cs
@@ -13,7 +13,7 @@ namespace NCalc
     {
         public EvaluateOptions Options { get; set; }
 
-        private bool IgnoreCase => (Options & EvaluateOptions.IgnoreCase) == EvaluateOptions.IgnoreCase;
+        private bool IgnoreCase { get { return (Options & EvaluateOptions.IgnoreCase) == EvaluateOptions.IgnoreCase; } }
 
         /// <summary>
         /// Textual representation of the expression to evaluate.


### PR DESCRIPTION
The original NCalc project page makes it sound as if Parameters are supposed to be included in the IgnoreCase evaluation option, however that is not the case.

http://ncalc.codeplex.com/wikipage?title=description&referringTitle=Home

This PR will make parameter evaluation case-insensitive too, if the IgnoreCase option is specified.
