### PR TITLE
Check for null when comparing using the most precise type.

### DIFF
--- a/Evaluant.Calculator.Tests/Fixtures.cs
+++ b/Evaluant.Calculator.Tests/Fixtures.cs
@@ -171,6 +171,38 @@ namespace NCalc.Tests
         }
 
         [Test]
+        public void ShouldCompareNullToNull()
+        {
+            var e = new Expression("[x] = null", EvaluateOptions.AllowNullParameter);
+
+            e.Parameters["x"] = null;
+
+            Assert.AreEqual(true, e.Evaluate());
+        }
+
+        [Test]
+        public void ShouldCompareNullableToNonNullable()
+        {
+            var e = new Expression("[x] = 5", EvaluateOptions.AllowNullParameter);
+
+            e.Parameters["x"] = (int?)5;
+            Assert.AreEqual(true, e.Evaluate());
+
+            e.Parameters["x"] = (int?)6;
+            Assert.AreEqual(false, e.Evaluate());
+        }
+
+        [Test]
+        public void ShouldCompareNullToString()
+        {
+            var e = new Expression("[x] = 'foo'", EvaluateOptions.AllowNullParameter);
+
+            e.Parameters["x"] = null;
+
+            Assert.AreEqual(false, e.Evaluate());
+        }
+
+        [Test]
         public void ExpressionDoesNotDefineNullParameterWithoutNullOption()
         {
             var e = new Expression("'a string' == null");

--- a/Evaluant.Calculator.Tests/Fixtures.cs
+++ b/Evaluant.Calculator.Tests/Fixtures.cs
@@ -335,7 +335,7 @@ namespace NCalc.Tests
         }
 
         [Test]
-        public void ShouldThrowAnExpcetionWhenInvalidNumber()
+        public void ShouldThrowAnExceptionWhenInvalidNumber()
         {
             try
             {

--- a/Evaluant.Calculator.Tests/Fixtures.cs
+++ b/Evaluant.Calculator.Tests/Fixtures.cs
@@ -147,6 +147,36 @@ namespace NCalc.Tests
         }
 
         [Test]
+        public void ExpressionShouldHandleNullRightParameters()
+        {
+            var e = new Expression("'a string' == null");
+            
+            e.Parameters["null"] = null;
+
+            Assert.AreEqual(false, e.Evaluate());
+        }
+
+        [Test]
+        public void ExpressionShouldHandleNullLeftParameters()
+        {
+            var e = new Expression("null == 'a string'");
+
+            e.Parameters["null"] = null;
+
+            Assert.AreEqual(false, e.Evaluate());
+        }
+
+        [Test]
+        public void ExpressionShouldHandleNullBothParameters()
+        {
+            var e = new Expression("null == null");
+
+            e.Parameters["null"] = null;
+
+            Assert.AreEqual(true, e.Evaluate());
+        }
+
+        [Test]
         public void ShouldEvaluateConditionnal()
         {
             var eif = new Expression("if([divider] <> 0, [divided] / [divider], 0)");

--- a/Evaluant.Calculator.Tests/Fixtures.cs
+++ b/Evaluant.Calculator.Tests/Fixtures.cs
@@ -149,9 +149,7 @@ namespace NCalc.Tests
         [Test]
         public void ExpressionShouldHandleNullRightParameters()
         {
-            var e = new Expression("'a string' == null");
-            
-            e.Parameters["null"] = null;
+            var e = new Expression("'a string' == null", EvaluateOptions.AllowNullParameter);
 
             Assert.AreEqual(false, e.Evaluate());
         }
@@ -159,9 +157,7 @@ namespace NCalc.Tests
         [Test]
         public void ExpressionShouldHandleNullLeftParameters()
         {
-            var e = new Expression("null == 'a string'");
-
-            e.Parameters["null"] = null;
+            var e = new Expression("null == 'a string'", EvaluateOptions.AllowNullParameter);
 
             Assert.AreEqual(false, e.Evaluate());
         }
@@ -169,11 +165,28 @@ namespace NCalc.Tests
         [Test]
         public void ExpressionShouldHandleNullBothParameters()
         {
-            var e = new Expression("null == null");
+            var e = new Expression("null == null", EvaluateOptions.AllowNullParameter);
+
+            Assert.AreEqual(true, e.Evaluate());
+        }
+
+        [Test]
+        public void ExpressionDoesNotDefineNullParameterWithoutNullOption()
+        {
+            var e = new Expression("'a string' == null");
+
+            var ex = Assert.Throws<ArgumentException>(() => e.Evaluate());
+            Assert.IsTrue(ex.Message.Contains("Parameter name: null"));
+        }
+
+        [Test]
+        public void ExpressionThrowsNullReferenceExceptionWithoutNullOption()
+        {
+            var e = new Expression("'a string' == null");
 
             e.Parameters["null"] = null;
 
-            Assert.AreEqual(true, e.Evaluate());
+            Assert.Throws<NullReferenceException>(() => e.Evaluate());
         }
 
         [Test]

--- a/Evaluant.Calculator/Domain/EvaluationVisitor.cs
+++ b/Evaluant.Calculator/Domain/EvaluationVisitor.cs
@@ -29,27 +29,27 @@ namespace NCalc.Domain
         private static readonly Type[] CommonTypes = { typeof(Int64), typeof(Double), typeof(Boolean), typeof(String), typeof(Decimal) };
 
         /// <summary>
-        /// Gets the the most precise type.
+        /// Gets the the most precise type of both objects.
         /// </summary>
-        /// <param name="a">Type a.</param>
-        /// <param name="b">Type b.</param>
+        /// <param name="a">Object a.</param>
+        /// <param name="b">Object b.</param>
         /// <returns></returns>
-        private static Type GetMostPreciseType(Type a, Type b)
+        private static Type GetMostPreciseType(object a, object b)
         {
             foreach (Type t in CommonTypes)
             {
-                if (a == t || b == t)
+                if ((a != null && a.GetType() == t) || (b != null && b.GetType() == t))
                 {
                     return t;
                 }
             }
 
-            return a;
+            return a != null ? a.GetType() : b != null ? b.GetType() : typeof(Object);
         }
 
         public int CompareUsingMostPreciseType(object a, object b)
         {
-            Type mpt = GetMostPreciseType(a.GetType(), b.GetType());
+            Type mpt = GetMostPreciseType(a, b);
             return Comparer.Default.Compare(Convert.ChangeType(a, mpt), Convert.ChangeType(b, mpt));
         }
 

--- a/Evaluant.Calculator/Domain/EvaluationVisitor.cs
+++ b/Evaluant.Calculator/Domain/EvaluationVisitor.cs
@@ -29,25 +29,6 @@ namespace NCalc.Domain
         private static readonly Type[] CommonTypes = { typeof(Int64), typeof(Double), typeof(Boolean), typeof(String), typeof(Decimal) };
 
         /// <summary>
-        /// Gets the the most precise type of both objects, even if one is null.
-        /// </summary>
-        /// <param name="a">Object a.</param>
-        /// <param name="b">Object b.</param>
-        /// <returns></returns>
-        private static Type GetMostPreciseType(object a, object b)
-        {
-            foreach (Type t in CommonTypes)
-            {
-                if ((a != null && a.GetType() == t) || (b != null && b.GetType() == t))
-                {
-                    return t;
-                }
-            }
-
-            return a != null ? a.GetType() : b != null ? b.GetType() : typeof(Object);
-        }
-
-        /// <summary>
         /// Gets the the most precise type of two types.
         /// </summary>
         /// <param name="a">Type a.</param>

--- a/Evaluant.Calculator/Domain/EvaluationVisitor.cs
+++ b/Evaluant.Calculator/Domain/EvaluationVisitor.cs
@@ -63,22 +63,16 @@ namespace NCalc.Domain
                 }
             }
 
-            return a;
+            return a ?? b;
         }
 
         public int CompareUsingMostPreciseType(object a, object b)
         {
-            Type mpt;
-
-            // Allow nulls to be compared with other values
-            if (options.AllowNullParameter())
-            {
-                mpt = GetMostPreciseType(a, b);
-                return Comparer.Default.Compare(Convert.ChangeType(a, mpt), Convert.ChangeType(b, mpt));
-            }
-
-            // No breaking changes fallback
-            mpt = GetMostPreciseType(a.GetType(), b.GetType());
+            Type mpt = options.AllowNullParameter()
+                // Allow nulls to be compared with other values
+                ? GetMostPreciseType(a?.GetType(), b?.GetType()) ?? typeof(object)
+                // No breaking changes fallback
+                : GetMostPreciseType(a.GetType(), b.GetType());
             return Comparer.Default.Compare(Convert.ChangeType(a, mpt), Convert.ChangeType(b, mpt));
         }
 

--- a/Evaluant.Calculator/Domain/EvaluationVisitor.cs
+++ b/Evaluant.Calculator/Domain/EvaluationVisitor.cs
@@ -29,7 +29,7 @@ namespace NCalc.Domain
         private static readonly Type[] CommonTypes = { typeof(Int64), typeof(Double), typeof(Boolean), typeof(String), typeof(Decimal) };
 
         /// <summary>
-        /// Gets the the most precise type of both objects.
+        /// Gets the the most precise type of both objects, even if one is null.
         /// </summary>
         /// <param name="a">Object a.</param>
         /// <param name="b">Object b.</param>
@@ -47,9 +47,38 @@ namespace NCalc.Domain
             return a != null ? a.GetType() : b != null ? b.GetType() : typeof(Object);
         }
 
+        /// <summary>
+        /// Gets the the most precise type of two types.
+        /// </summary>
+        /// <param name="a">Type a.</param>
+        /// <param name="b">Type b.</param>
+        /// <returns></returns>
+        private static Type GetMostPreciseType(Type a, Type b)
+        {
+            foreach (Type t in CommonTypes)
+            {
+                if (a == t || b == t)
+                {
+                    return t;
+                }
+            }
+
+            return a;
+        }
+
         public int CompareUsingMostPreciseType(object a, object b)
         {
-            Type mpt = GetMostPreciseType(a, b);
+            Type mpt;
+
+            // Allow nulls to be compared with other values
+            if (options.AllowNullParameter())
+            {
+                mpt = GetMostPreciseType(a, b);
+                return Comparer.Default.Compare(Convert.ChangeType(a, mpt), Convert.ChangeType(b, mpt));
+            }
+
+            // No breaking changes fallback
+            mpt = GetMostPreciseType(a.GetType(), b.GetType());
             return Comparer.Default.Compare(Convert.ChangeType(a, mpt), Convert.ChangeType(b, mpt));
         }
 

--- a/Evaluant.Calculator/EvaluationOption.cs
+++ b/Evaluant.Calculator/EvaluationOption.cs
@@ -29,7 +29,12 @@ namespace NCalc
         //
         // Summary:
         //     When using Round(), if a number is halfway between two others, it is rounded toward the nearest number that is away from zero.
-        RoundAwayFromZero = 16
+        RoundAwayFromZero = 16,
+
+        //
+        // Summary:
+        //     Defines a "null" parameter and allows comparison of values to null.
+        AllowNullParameter = 32
     }
 
     internal static class EvaluateOptionsExtensions
@@ -57,6 +62,11 @@ namespace NCalc
         public static bool RoundAwayFromZero(this EvaluateOptions opts)
         {
             return opts.Has(EvaluateOptions.RoundAwayFromZero);
+        }
+
+        public static bool AllowNullParameter(this EvaluateOptions opts)
+        {
+            return opts.Has(EvaluateOptions.AllowNullParameter);
         }
     }
 }

--- a/Evaluant.Calculator/Expression.cs
+++ b/Evaluant.Calculator/Expression.cs
@@ -196,6 +196,13 @@ namespace NCalc
             visitor.EvaluateParameter += EvaluateParameter;
             visitor.Parameters = Parameters;
 
+            // Add a "null" parameter which returns null if configured to do so
+            // Configured as an option to ensure no breaking changes for historical use
+            if (Options.AllowNullParameter() && !visitor.Parameters.ContainsKey("null"))
+            {
+                visitor.Parameters["null"] = null;
+            }
+
             // if array evaluation, execute the same expression multiple times
             if (Options.IterateParameters())
             {


### PR DESCRIPTION
This allows null value parameters to be used in expressions such as `'a string' == null` where null is defined as `e.Parameters["null"] = null;`.

Some of my custom functions can return null and there are cases where I need to detect that. Currently the code is calling `GetType()` on the null and getting a null reference exception.