### PR TITLE
Fix problem with the functions that return null when they are operated with other parameters

### DIFF
--- a/Evaluant.Calculator.Tests/Fixtures.cs
+++ b/Evaluant.Calculator.Tests/Fixtures.cs
@@ -203,12 +203,22 @@ namespace NCalc.Tests
         }
 
         [Test]
+        public void ShouldCompareNullToInt()
+        {
+            var e = new Expression("[x] = 4", EvaluateOptions.AllowNullParameter);
+
+            e.Parameters["x"] = null;
+
+            Assert.AreEqual(false, e.Evaluate());
+        }
+
+        [Test]
         public void ExpressionDoesNotDefineNullParameterWithoutNullOption()
         {
             var e = new Expression("'a string' == null");
 
             var ex = Assert.Throws<ArgumentException>(() => e.Evaluate());
-            Assert.IsTrue(ex.Message.Contains("Parameter name: null"));
+            Assert.IsTrue(ex.Message.Contains("Parameter was not defined"));
         }
 
         [Test]
@@ -619,6 +629,74 @@ namespace NCalc.Tests
             };
 
             Assert.AreEqual(null, e.Evaluate());
+        }
+
+        [Test]
+        public void ExpressionShouldEvaluateSumCustomFunctionsWithParametersThatReturnsNull()
+        {
+            var e = new Expression("SecretOperation(3, 6) + f");
+            e.Parameters["f"] = 5;
+
+            e.EvaluateFunction += delegate (string name, FunctionArgs args)
+            {
+                Assert.IsFalse(args.HasResult);
+                if (name == "SecretOperation")
+                    args.Result = null;
+                Assert.IsTrue(args.HasResult);
+            };
+
+            Assert.AreEqual(null, e.Evaluate());
+        }
+
+        [Test]
+        public void ExpressionShouldEvaluateDivideCustomFunctionsWithParametersThatReturnsNull()
+        {
+            var e = new Expression("SecretOperation(3, 6) / f");
+            e.Parameters["f"] = 5;
+
+            e.EvaluateFunction += delegate (string name, FunctionArgs args)
+            {
+                Assert.IsFalse(args.HasResult);
+                if (name == "SecretOperation")
+                    args.Result = null;
+                Assert.IsTrue(args.HasResult);
+            };
+
+            Assert.AreEqual(null, e.Evaluate());
+        }
+
+        [Test]
+        public void ExpressionShouldEvaluateCompareCustomFunctionsWithParametersThatReturnsNull()
+        {
+            var e = new Expression("SecretOperation(3, 6) = f");
+            e.Parameters["f"] = 5;
+
+            e.EvaluateFunction += delegate (string name, FunctionArgs args)
+            {
+                Assert.IsFalse(args.HasResult);
+                if (name == "SecretOperation")
+                    args.Result = null;
+                Assert.IsTrue(args.HasResult);
+            };
+
+            Assert.Throws<NullReferenceException>(() => e.Evaluate());
+        }
+
+        [Test]
+        public void ExpressionShouldEvaluateSumCustomFunctionsWithParametersThatReturnsNullWithAllowNullParameter()
+        {
+            var e = new Expression("SecretOperation(3, 6) = f", EvaluateOptions.AllowNullParameter);
+            e.Parameters["f"] = 5;
+
+            e.EvaluateFunction += delegate (string name, FunctionArgs args)
+            {
+                Assert.IsFalse(args.HasResult);
+                if (name == "SecretOperation")
+                    args.Result = null;
+                Assert.IsTrue(args.HasResult);
+            };
+
+            Assert.AreEqual(false, e.Evaluate());
         }
 
         [Test]

--- a/Evaluant.Calculator/Domain/EvaluationVisitor.cs
+++ b/Evaluant.Calculator/Domain/EvaluationVisitor.cs
@@ -49,6 +49,11 @@ namespace NCalc.Domain
 
         public int CompareUsingMostPreciseType(object a, object b)
         {
+            //If any of the paremeter that is null, not is a string the method ChangeType fails
+            if ((a == null || b == null) && (a != b) && options.AllowNullParameter())
+            {
+                return -1;
+            }
             Type mpt = options.AllowNullParameter()
                 // Allow nulls to be compared with other values
                 ? GetMostPreciseType(a?.GetType(), b?.GetType()) ?? typeof(object)
@@ -74,7 +79,7 @@ namespace NCalc.Domain
         }
 
         private static bool IsReal(object value)
-        {
+        {   
             var typeCode = Type.GetTypeCode(value.GetType());
 
             return typeCode == TypeCode.Decimal || typeCode == TypeCode.Double || typeCode == TypeCode.Single;
@@ -117,9 +122,16 @@ namespace NCalc.Domain
                     break;
 
                 case BinaryExpressionType.Div:
-                    Result = IsReal(left()) || IsReal(right())
-                                 ? Numbers.Divide(left(), right())
-                                 : Numbers.Divide(Convert.ToDouble(left()), right());
+                    if (left() == null || right() == null)
+                    {
+                        Result = null;
+                    }
+                    else
+                    {
+                        Result = IsReal(left()) || IsReal(right())
+                                     ? Numbers.Divide(left(), right())
+                                     : Numbers.Divide(Convert.ToDouble(left()), right());
+                    }
                     break;
 
                 case BinaryExpressionType.Equal:

--- a/Evaluant.Calculator/Numbers.cs
+++ b/Evaluant.Calculator/Numbers.cs
@@ -19,6 +19,11 @@ namespace NCalc
             a = ConvertIfString(a);
             b = ConvertIfString(b);
 
+            if (a == null || b == null)
+            {
+                return null;
+            }
+
             TypeCode typeCodeA = Type.GetTypeCode(a.GetType());
             TypeCode typeCodeB = Type.GetTypeCode(b.GetType());
 
@@ -249,6 +254,11 @@ namespace NCalc
             a = ConvertIfString(a);
             b = ConvertIfString(b);
 
+            if (a == null || b == null)
+            {
+                return null;
+            }
+
             TypeCode typeCodeA = Type.GetTypeCode(a.GetType());
             TypeCode typeCodeB = Type.GetTypeCode(b.GetType());
 
@@ -468,6 +478,11 @@ namespace NCalc
             a = ConvertIfString(a);
             b = ConvertIfString(b);
 
+            if (a == null || b == null)
+            {
+                return null;
+            }
+
             TypeCode typeCodeA = Type.GetTypeCode(a.GetType());
             TypeCode typeCodeB = Type.GetTypeCode(b.GetType());
 
@@ -668,6 +683,11 @@ namespace NCalc
         {
             a = ConvertIfString(a);
             b = ConvertIfString(b);
+
+            if (a == null || b == null)
+            {
+                return null;
+            }
 
             TypeCode typeCodeA = Type.GetTypeCode(a.GetType());
             TypeCode typeCodeB = Type.GetTypeCode(b.GetType());


### PR DESCRIPTION
-Fix problem with the functions that return null when they are operated with other parameters, either in sum, divisions, etc. or in comparisons.
-For comparisons it is necessary to allow null parameters with AllowNullParameter
-Modify comparison method since when comparing a parameter with null value and an integer, it failed.
-Add tests to validate the changes made
-Fix test that failed because the message of the exception was in Spanish and in the test was compared with a message in English