### PR TITLE
Handled empty string compares

### DIFF
--- a/Evaluant.Calculator.Tests/Fixtures.cs
+++ b/Evaluant.Calculator.Tests/Fixtures.cs
@@ -718,18 +718,55 @@ namespace NCalc.Tests
         [Test]
         public void ShouldCompareStringWithNumber()
         {
-
-            Assert.AreEqual(false, new Expression("'' = 5", EvaluateOptions.AllowNullParameter).Evaluate());
-            Assert.AreEqual(false, new Expression("0.5 = ''", EvaluateOptions.AllowNullParameter).Evaluate());
-            Assert.AreEqual(false, new Expression("20 = ''", EvaluateOptions.AllowNullParameter).Evaluate());
-            Assert.AreEqual(false, new Expression("'Not number' = 0.5", EvaluateOptions.AllowNullParameter).Evaluate());
-            Assert.AreEqual(true, new Expression("'5' = '5'", EvaluateOptions.AllowNullParameter).Evaluate());
-            Assert.AreEqual(true, new Expression("'0.5' = 0.5", EvaluateOptions.AllowNullParameter).Evaluate());
-            Assert.AreEqual(false, new Expression("20 = '0.5'", EvaluateOptions.AllowNullParameter).Evaluate());
-            Assert.AreEqual(false, new Expression("'30' = '0.5'", EvaluateOptions.AllowNullParameter).Evaluate());
-            Assert.AreEqual(22.5, new Expression("if('' = '',0.50,0.25) + 22", EvaluateOptions.AllowNullParameter).Evaluate());
-            Assert.AreEqual(22.25, new Expression("if('Yes' = '',0.50,0.25) + 22", EvaluateOptions.AllowNullParameter).Evaluate());
+            Assert.AreEqual(false, new Expression("'' = 5").Evaluate());
+            Assert.AreEqual(false, new Expression("20 = ''").Evaluate());
+            Assert.AreEqual(false, new Expression("'' = 5").Evaluate());
+            Assert.AreEqual(false, new Expression("20 = ''").Evaluate());
+            Assert.AreEqual(false, new Expression("0.5 = ''").Evaluate());
+            Assert.AreEqual(false, new Expression("'Not number' = 0.5").Evaluate());
+            Assert.AreEqual(true, new Expression("'5' = '5'").Evaluate());
+            Assert.AreEqual(true, new Expression("'0.5' = 0.5").Evaluate());
+            Assert.AreEqual(false, new Expression("20 = '0.5'").Evaluate());
+            Assert.AreEqual(false, new Expression("'30' = '0.5'").Evaluate());
+            Assert.AreEqual(22.5, new Expression("if('' = '',0.50,0.25) + 22").Evaluate());
+            Assert.AreEqual(22.25, new Expression("if('Yes' = '',0.50,0.25) + 22").Evaluate());
 
         }
+
+
+        [Test]
+        public void ShouldEvaluateStringOperators()
+        {
+            var expressions = new Dictionary<string, object>
+                                  {
+                                      {"!'true'", false},
+                                      {"not 'false'", true},
+                                      {"'1' < '2'", true},
+                                      {"'1' > '2'", false},
+                                      {"'1' <= '2'", true},
+                                      {"'1' <= '1'", true},
+                                      {"'1' >= '2'", false},
+                                      {"'1' >= '1'", true},
+                                      {"'1' = '1'", true},
+                                      {"'1' == '1'", true},
+                                      {"'1' != '1'", false},
+                                      {"'1' <> '1'", false},
+                                      {"'1' & '1'", 1},
+                                      {"'1' | '1'", 1},
+                                      {"'1' ^ '1'", 0},
+                                      {"'true' && 'false'", false},
+                                      {"'true' and 'false'", false},
+                                      {"'true' || 'false'", true},
+                                      {"'true' or 'false'", true},
+                                      {"if('true', 0, 1)", 0},
+                                      {"if('false', 0, 1)", 1}
+                                  };
+
+            foreach (KeyValuePair<string, object> pair in expressions)
+            {
+                Assert.AreEqual(pair.Value, new Expression(pair.Key).Evaluate(), pair.Key + " failed");
+            }
+        }
+
     }
 }

--- a/Evaluant.Calculator.Tests/Fixtures.cs
+++ b/Evaluant.Calculator.Tests/Fixtures.cs
@@ -714,5 +714,22 @@ namespace NCalc.Tests
 
             Assert.AreEqual(false, e.Evaluate());
         }
+
+        [Test]
+        public void ShouldCompareStringWithNumber()
+        {
+
+            Assert.AreEqual(false, new Expression("'' = 5", EvaluateOptions.AllowNullParameter).Evaluate());
+            Assert.AreEqual(false, new Expression("0.5 = ''", EvaluateOptions.AllowNullParameter).Evaluate());
+            Assert.AreEqual(false, new Expression("20 = ''", EvaluateOptions.AllowNullParameter).Evaluate());
+            Assert.AreEqual(false, new Expression("'Not number' = 0.5", EvaluateOptions.AllowNullParameter).Evaluate());
+            Assert.AreEqual(true, new Expression("'5' = '5'", EvaluateOptions.AllowNullParameter).Evaluate());
+            Assert.AreEqual(true, new Expression("'0.5' = 0.5", EvaluateOptions.AllowNullParameter).Evaluate());
+            Assert.AreEqual(false, new Expression("20 = '0.5'", EvaluateOptions.AllowNullParameter).Evaluate());
+            Assert.AreEqual(false, new Expression("'30' = '0.5'", EvaluateOptions.AllowNullParameter).Evaluate());
+            Assert.AreEqual(22.5, new Expression("if('' = '',0.50,0.25) + 22", EvaluateOptions.AllowNullParameter).Evaluate());
+            Assert.AreEqual(22.25, new Expression("if('Yes' = '',0.50,0.25) + 22", EvaluateOptions.AllowNullParameter).Evaluate());
+
+        }
     }
 }

--- a/Evaluant.Calculator/Domain/EvaluationVisitor.cs
+++ b/Evaluant.Calculator/Domain/EvaluationVisitor.cs
@@ -40,6 +40,8 @@ namespace NCalc.Domain
             {
                 if (a == t || b == t)
                 {
+                    if (b == typeof(String) || a == typeof(String)) return typeof(String);
+
                     return t;
                 }
             }


### PR DESCRIPTION
GetMostPreciseType CommonTypes which it will start to check if the left side is "Int64" or right side is "Int64" then it will move to check if the left side is "Double" or right side is "Double" and it goes on, now if you see it start with Int64,Double,Boolean and last thing is Decimal the best way to explain this is by examples before moving there GetMostPreciseType it's a method to check the precise type to convert the right and left side based on the result just keep in mind we start to check from the left to right

'' = 4 -> string
20 = '' -> string
0.5 = '' -> double *
'' = 0.5 -> double*
my fixed will change the double to string as double will performed before string in the foreach loop when you compere take in place between two string

basically, it changes any type to string if any of the sides of compering is not a string  